### PR TITLE
feat(db): Define core data entities

### DIFF
--- a/src/expenses/entities/expense.entity.ts
+++ b/src/expenses/entities/expense.entity.ts
@@ -1,0 +1,28 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, ManyToMany, JoinTable } from 'typeorm';
+import { Trip } from '../../trips/entities/trip.entity';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('expenses')
+export class Expense {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  title: string;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  amount: number;
+
+  @ManyToOne(() => User)
+  payer: User;
+
+  @ManyToMany(() => User)
+  @JoinTable()
+  sharedWith: User[];
+
+  @ManyToOne(() => Trip, trip => trip.expenses)
+  trip: Trip;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/trips/entities/trip.entity.ts
+++ b/src/trips/entities/trip.entity.ts
@@ -1,0 +1,31 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToMany, JoinTable, OneToMany, ManyToOne } from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { Expense } from '../../expenses/entities/expense.entity';
+
+@Entity('trips')
+export class Trip {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column()
+  currency: string;
+
+  @Column({ unique: true })
+  code: string;
+
+  @ManyToOne(() => User)
+  creator: User;
+
+  @ManyToMany(() => User, user => user.trips)
+  @JoinTable()
+  participants: User[];
+
+  @OneToMany(() => Expense, expense => expense.trip)
+  expenses: Expense[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToMany } from 'typeorm';
+import { Trip } from '../../trips/entities/trip.entity';
+
+@Entity('users')
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true })
+  email: string;
+
+  @Column()
+  name: string;
+
+  @Column()
+  password: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ManyToMany(() => Trip, trip => trip.participants)
+  trips: Trip[];
+}


### PR DESCRIPTION
This pull request introduces new entity definitions for the core domain models in the application, laying the foundation for relationships between users, trips, and expenses. These entities are set up using TypeORM decorators to enable object-relational mapping and to establish connections between tables.

**Entity Definitions and Relationships**

* Added the `User` entity with fields for `id`, `email`, `name`, `password`, and a many-to-many relationship to `Trip` via the `trips` property. (`src/users/entities/user.entity.ts`)
* Added the `Trip` entity with fields for `id`, `name`, `currency`, `code`, and relationships to its `creator` (`User`), `participants` (`User[]`), and associated `expenses` (`Expense[]`). (`src/trips/entities/trip.entity.ts`)
* Added the `Expense` entity with fields for `id`, `title`, `amount`, and relationships to its `payer` (`User`), users it is `sharedWith` (`User[]`), and the associated `trip` (`Trip`). (`src/expenses/entities/expense.entity.ts`)