### PR TITLE
feat(common): Add shared JWT guard and validation pipe

### DIFF
--- a/src/common/guards/auth.guard.ts
+++ b/src/common/guards/auth.guard.ts
@@ -1,0 +1,19 @@
+import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const userId = request.headers['user-id'];
+
+    if (!userId) {
+      throw new UnauthorizedException('Usuario no autenticado');
+    }
+
+    request.userId = userId;
+    return true;
+  }
+}

--- a/src/common/pipes/validation.pipe.ts
+++ b/src/common/pipes/validation.pipe.ts
@@ -1,0 +1,29 @@
+import { PipeTransform, Injectable, ArgumentMetadata, BadRequestException } from '@nestjs/common';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+
+@Injectable()
+export class ValidationPipe implements PipeTransform<any> {
+  async transform(value: any, { metatype }: ArgumentMetadata) {
+    if (!metatype || !this.toValidate(metatype)) {
+      return value;
+    }
+
+    const object = plainToInstance(metatype, value);
+    const errors = await validate(object);
+
+    if (errors.length > 0) {
+      const messages = errors.map(err => {
+        return Object.values(err.constraints ?? {}).join(', ');
+      });
+      throw new BadRequestException(messages);
+    }
+
+    return value;
+  }
+
+  private toValidate(metatype: Function): boolean {
+    const types: Function[] = [String, Boolean, Number, Array, Object];
+    return !types.includes(metatype);
+  }
+}


### PR DESCRIPTION
This pull request introduces two new reusable components to improve authentication and request validation in the codebase. It adds a custom authentication guard to enforce user authentication via headers, and a validation pipe to ensure incoming request data conforms to expected DTOs.

Authentication enhancements:

* Added a new `AuthGuard` class in `src/common/guards/auth.guard.ts` to check for a `user-id` header and throw an `UnauthorizedException` if missing, ensuring requests are authenticated.

Validation improvements:

* Added a new `ValidationPipe` class in `src/common/pipes/validation.pipe.ts` to validate incoming request bodies against DTOs using `class-validator` and `class-transformer`, throwing a `BadRequestException` with detailed error messages if validation fails.