### PR TITLE
feat(trips): Implement trip creation and management

### DIFF
--- a/src/trips/dto/create-trip.dto.ts
+++ b/src/trips/dto/create-trip.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsArray, IsIn, ArrayMaxSize } from 'class-validator';
+
+export class CreateTripDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  @IsIn(['COP', 'USD'])
+  currency: string;
+
+  @IsArray()
+  @ArrayMaxSize(20)
+  participantEmails: string[];
+}

--- a/src/trips/dto/join-trip.dto.ts
+++ b/src/trips/dto/join-trip.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class JoinTripDto {
+  @IsString()
+  code: string;
+}

--- a/src/trips/trips.controller.ts
+++ b/src/trips/trips.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Post, Body, Param, UseGuards, Request } from '@nestjs/common';
+import { TripsService } from './trips.service';
+import { CreateTripDto } from './dto/create-trip.dto';
+import { JoinTripDto } from './dto/join-trip.dto';
+import { AuthGuard } from '../common/guards/auth.guard';
+
+@Controller('trips')
+@UseGuards(AuthGuard)
+export class TripsController {
+  constructor(private tripsService: TripsService) {}
+
+  @Post()
+  create(@Request() req, @Body() createTripDto: CreateTripDto) {
+    return this.tripsService.create(req.userId, createTripDto);
+  }
+
+  @Get()
+  findUserTrips(@Request() req) {
+    return this.tripsService.findUserTrips(req.userId);
+  }
+
+  @Post('join')
+  join(@Request() req, @Body() joinTripDto: JoinTripDto) {
+    return this.tripsService.join(req.userId, joinTripDto);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string, @Request() req) {
+    return this.tripsService.findOne(id, req.userId);
+  }
+}

--- a/src/trips/trips.module.ts
+++ b/src/trips/trips.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TripsController } from './trips.controller';
+import { TripsService } from './trips.service';
+import { Trip } from './entities/trip.entity';
+import { User } from '../users/entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Trip, User])],
+  controllers: [TripsController],
+  providers: [TripsService],
+})
+export class TripsModule {}

--- a/src/trips/trips.service.ts
+++ b/src/trips/trips.service.ts
@@ -1,0 +1,142 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Trip } from './entities/trip.entity';
+import { User } from '../users/entities/user.entity';
+import { CreateTripDto } from './dto/create-trip.dto';
+import { JoinTripDto } from './dto/join-trip.dto';
+
+@Injectable()
+export class TripsService {
+  constructor(
+    @InjectRepository(Trip)
+    private tripRepository: Repository<Trip>,
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+  ) {}
+
+  private generateCode(): string {
+    return Math.random().toString(36).substring(2, 8).toUpperCase();
+  }
+
+  async create(userId: string, createTripDto: CreateTripDto) {
+    // ✅ Validar que el creador existe
+    const creator = await this.userRepository.findOne({ where: { id: userId } });
+    
+    if (!creator) {
+      throw new NotFoundException('Usuario no encontrado');
+    }
+
+    const participants = await this.userRepository.find({
+      where: createTripDto.participantEmails.map(email => ({ email })),
+    });
+
+    if (!participants.find(p => p.id === userId)) {
+      participants.push(creator);
+    }
+
+    const trip = this.tripRepository.create({
+      name: createTripDto.name,
+      currency: createTripDto.currency,
+      code: this.generateCode(),
+      creator,
+      participants,
+    });
+
+    await this.tripRepository.save(trip);
+
+    return {
+      message: 'Viaje creado exitosamente',
+      trip: {
+        id: trip.id,
+        name: trip.name,
+        currency: trip.currency,
+        code: trip.code,
+      },
+    };
+  }
+
+  async findUserTrips(userId: string) {
+    const trips = await this.tripRepository
+      .createQueryBuilder('trip')
+      .leftJoin('trip.participants', 'participant')
+      .where('participant.id = :userId', { userId })
+      .select(['trip.id', 'trip.name', 'trip.currency', 'trip.code'])
+      .getMany();
+
+    return trips;
+  }
+
+  async join(userId: string, joinTripDto: JoinTripDto) {
+    const trip = await this.tripRepository.findOne({
+      where: { code: joinTripDto.code },
+      relations: ['participants'],
+    });
+
+    if (!trip) {
+      throw new NotFoundException('Código de viaje inválido');
+    }
+
+    // ✅ Validar que el usuario existe
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    
+    if (!user) {
+      throw new NotFoundException('Usuario no encontrado');
+    }
+
+    if (trip.participants.some(p => p.id === userId)) {
+      throw new BadRequestException('Ya estás en este viaje');
+    }
+
+    if (trip.participants.length >= 20) {
+      throw new BadRequestException('El viaje ya tiene el máximo de participantes');
+    }
+
+    trip.participants.push(user);
+    await this.tripRepository.save(trip);
+
+    return {
+      message: 'Te has unido al viaje exitosamente',
+      trip: {
+        id: trip.id,
+        name: trip.name,
+      },
+    };
+  }
+
+  async findOne(id: string, userId: string) {
+    const trip = await this.tripRepository.findOne({
+      where: { id },
+      relations: ['participants', 'expenses', 'expenses.payer'],
+    });
+
+    if (!trip) {
+      throw new NotFoundException('Viaje no encontrado');
+    }
+
+    const isParticipant = trip.participants.some(p => p.id === userId);
+    if (!isParticipant) {
+      throw new BadRequestException('No eres parte de este viaje');
+    }
+
+    const totalExpenses = trip.expenses.reduce((sum, exp) => sum + Number(exp.amount), 0);
+    const userExpenses = trip.expenses
+      .filter(exp => exp.payer.id === userId)
+      .reduce((sum, exp) => sum + Number(exp.amount), 0);
+
+    return {
+      id: trip.id,
+      name: trip.name,
+      currency: trip.currency,
+      totalExpenses,
+      userExpenses,
+      expenses: trip.expenses.map(exp => ({
+        id: exp.id,
+        title: exp.title,
+        amount: exp.amount,
+        payer: exp.payer.name,
+        date: exp.createdAt,
+      })),
+    };
+  }
+}


### PR DESCRIPTION
This pull request introduces a new trips feature, including the ability to create, join, and view trips, along with participant management and expense summaries. The implementation covers the controller, service logic, data transfer objects (DTOs), and module setup, all protected by authentication.

**Trips feature implementation**

* Added `TripsController` with endpoints to create a trip, join a trip, list user trips, and view trip details, all protected by `AuthGuard`. (`src/trips/trips.controller.ts`)
* Implemented `TripsService` with logic for trip creation, user validation, participant management, joining trips, and returning detailed trip summaries including expenses. (`src/trips/trips.service.ts`)
* Defined DTOs for trip creation (`CreateTripDto`) and joining trips (`JoinTripDto`), including validation for fields such as participant emails and currency. (`src/trips/dto/create-trip.dto.ts`, `src/trips/dto/join-trip.dto.ts`) [[1]](diffhunk://#diff-47d91e25dfff33dacfbd5cf2b635e893f56fd9d9f7c2bb7fecf99ccd1ac1e71aR1-R14) [[2]](diffhunk://#diff-fb937e8cbe8d9f6d34a2bc9681e2b9521459dae9e4960e9016ac1f10c3a56d20R1-R6)

**Module setup**

* Registered `TripsModule` with necessary imports, controllers, and providers, wiring up `Trip` and `User` entities for database access. (`src/trips/trips.module.ts`)